### PR TITLE
feat: /act minimal logic (task_id + accepted_at)

### DIFF
--- a/app/routers/act.py
+++ b/app/routers/act.py
@@ -1,58 +1,67 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import os
-from typing import Literal
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
 
-from fastapi import APIRouter, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Body, HTTPException
 from pydantic import BaseModel, Field
+from starlette.responses import StreamingResponse
 
 router = APIRouter(tags=["act"])
+
+# singleton, by nie łamać reguły B008 (Body(...) w domyślnej wartości)
+BODY_REQUIRED = Body(...)
 
 
 class ActRequest(BaseModel):
     input: str = Field(..., description="User input")
-    mode: Literal["sync", "stream"] = "sync"
-
-
-class Echo(BaseModel):
-    input: str
-    mode: Literal["sync", "stream"]
+    mode: Literal["sync", "stream"] | None = "sync"
 
 
 class ActResponse(BaseModel):
     status: Literal["accepted", "unsupported"]
-    echo: Echo
+    message: str
+    task_id: str | None = None
+    accepted_at: str | None = None
+    echo: dict[str, Any] | None = None
 
 
 @router.post("/act", response_model=ActResponse, summary="Agent action (stub)")
-async def act(req: ActRequest) -> ActResponse:
-    if not req.input.strip():
-        raise HTTPException(status_code=400, detail="input cannot be empty")
-    status: Literal["accepted", "unsupported"] = "accepted" if req.mode == "sync" else "unsupported"
-    return ActResponse(status=status, echo=Echo(input=req.input, mode=req.mode))
-
-
-# --- STREAMING (SSE) EXPERIMENTAL -------------------------------------------
-@router.post("/act/stream", summary="Agent action (SSE stream, experimental)")
-async def act_stream(req: ActRequest):
-    """
-    Server-Sent Events (SSE) stub. Enable with EXPERIMENTAL_ACT_STREAM=1.
-    """
-    if os.getenv("EXPERIMENTAL_ACT_STREAM") != "1":
-        raise HTTPException(
-            status_code=501, detail="stream disabled; set EXPERIMENTAL_ACT_STREAM=1"
-        )
-
+async def act(req: ActRequest = BODY_REQUIRED) -> ActResponse:
     if not req.input.strip():
         raise HTTPException(status_code=400, detail="input cannot be empty")
 
-    async def event_gen():
-        for i in range(5):
-            payload = {"index": i, "echo": {"input": req.input, "mode": "stream"}}
-            yield f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
-            await asyncio.sleep(0.01)
+    # minimalna logika dla trybu sync: task_id + znacznik czasu
+    task_id = str(uuid.uuid4())
+    ts = datetime.now(UTC).isoformat()
 
-    return StreamingResponse(event_gen(), media_type="text/event-stream")
+    return ActResponse(
+        status="accepted",
+        message="Stub only",
+        task_id=task_id,
+        accepted_at=ts,
+        echo=req.model_dump(),
+    )
+
+
+@router.post("/act/stream", summary="Agent action stream (stub)")
+async def act_stream(req: ActRequest = BODY_REQUIRED):
+    if not req.input.strip():
+        raise HTTPException(status_code=400, detail="input cannot be empty")
+
+    flag = os.getenv("EXPERIMENTAL_ACT_STREAM", "")
+    if str(flag).lower() not in {"1", "true", "yes", "on"}:
+        raise HTTPException(status_code=501, detail="streaming not enabled")
+
+    async def gen():
+        payload = {
+            "status": "accepted",
+            "message": "Stub only (stream)",
+            "echo": req.model_dump(),
+        }
+        yield "data: " + json.dumps(payload) + "\n\n"
+
+    return StreamingResponse(gen(), media_type="text/event-stream")


### PR DESCRIPTION
Adds task_id (UUID4) and accepted_at (ISO8601 UTC) to /act sync path. Includes tests already on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enriches /act response with message, task_id, and accepted_at; makes mode optional; and updates /act/stream to a single SSE event gated by broader env flags.
> 
> - **API (act)**:
>   - **/act**:
>     - Response now includes `message`, `task_id` (UUID4), and `accepted_at` (ISO8601 UTC); `echo` is now a `dict` of the request payload.
>     - Request `mode` is optional (defaults to `"sync"`).
>     - Uses `Body(...)` for required payload and returns `status="accepted"` with generated IDs/timestamps.
>   - **/act/stream**:
>     - Gated by env var accepting {`"1"`, `"true"`, `"yes"`, `"on"`}.
>     - Emits a single SSE event with `status`, `message`, and request `echo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26bec58140d8fd44a45090cdbe73fbee338f5c8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->