### PR TITLE
ci/buildx gha cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ build/
 .vscode/
 .idea/
 .DS_Store
+/agent-local/data/
+/agent-local/agent_app/

--- a/agent-local/.github/workflows/build-image.yml
+++ b/agent-local/.github/workflows/build-image.yml
@@ -1,0 +1,41 @@
+name: Build & Push Image
+on:
+  push:
+    branches: ['**']
+  pull_request:
+    branches: ['**']
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # wymuszenie małych liter w pełnej nazwie obrazu
+      - name: Prepare image name (lowercase)
+        run: |
+          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+          echo "TAG_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ env.TAG_SHA }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/agent-local/.github/workflows/build-image.yml
+++ b/agent-local/.github/workflows/build-image.yml
@@ -1,13 +1,15 @@
 name: Build & Push Image
 on:
   push:
-    branches: ['**']
+    branches: ['**']   # build na każdej gałęzi
+    tags: ['v*']       # oraz na tagach wersji (vX.Y.Z)
   pull_request:
     branches: ['**']
   workflow_dispatch:
+
 permissions:
   contents: read
-  packages: write
+  packages: write       # wymagane do push do GHCR
 
 jobs:
   build:
@@ -15,33 +17,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # >>> tu włączamy builder na driverze docker-container (wymagany do cache type=gha)
+      # Buildx na driverze docker-container (wymagany dla cache type=gha)
       - uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
           install: true
-          buildkitd-flags: --debug
 
+      # Logowanie do GHCR
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Prepare image name (lowercase)
-        run: |
-          echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
-          echo "TAG_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
+      # Metadane/tagi obrazów
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
 
+      # Budowa i push z cache w GitHub Actions
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ env.TAG_SHA }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/agent-local/.github/workflows/build-image.yml
+++ b/agent-local/.github/workflows/build-image.yml
@@ -14,14 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # >>> tu włączamy builder na driverze docker-container (wymagany do cache type=gha)
       - uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
+          buildkitd-flags: --debug
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # wymuszenie małych liter w pełnej nazwie obrazu
       - name: Prepare image name (lowercase)
         run: |
           echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV

--- a/agent-local/compose.override.yml
+++ b/agent-local/compose.override.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    # publikuj port kontenera 8000 na hosta (z .env: APP_BIND/APP_PORT)
+    ports:
+      - "${APP_BIND:-127.0.0.1}:${APP_PORT:-8000}:8000"
+    # healthcheck bez zależności od curl/wget (Python socket)
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import socket,sys; s=socket.socket(); s.settimeout(2); s.connect(('localhost',8000)); s.close(); sys.exit(0)\""]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 10s

--- a/agent-local/compose.yml
+++ b/agent-local/compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    image: ghcr.io/erykjuraszczyk-ui/agentcortana-app:${APP_VERSION:-latest}
+    restart: unless-stopped
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower
+    command: --label-enable --interval 300
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped


### PR DESCRIPTION
- **ci: build & push to GHCR (lowercase tags, GHA cache)**
- **ci: use buildx docker-container driver (enable GHA cache)**
- **ci: buildx docker-container + metadata + gha cache + ghcr push**
- **compose: keep only compose.yml; remove legacy docker-compose.***
- **chore: ignore local data dirs for agent-local**
- **compose: ports + healthcheck; env defaults**
